### PR TITLE
added promoteOrderId to the order requests

### DIFF
--- a/php/src/Snagshout/Promote/Model/CancelRebateRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/CancelRebateRequestBody.php
@@ -53,7 +53,7 @@ class CancelRebateRequestBody
      *
      * @return self
      */
-    public function setPromoteOrderId(int $promoteOrderId = null): ConfirmRebateRequestBody
+    public function setPromoteOrderId(int $promoteOrderId = null): CancelRebateRequestBody
     {
         $this->promoteOrderId = $promoteOrderId;
 

--- a/php/src/Snagshout/Promote/Model/CancelRebateRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/CancelRebateRequestBody.php
@@ -18,6 +18,10 @@ class CancelRebateRequestBody
      */
     protected $email;
     /**
+     * @var int
+     */
+    protected $promoteOrderId;
+    /**
      * @return string
      */
     public function getEmail()
@@ -32,6 +36,26 @@ class CancelRebateRequestBody
     public function setEmail($email = null)
     {
         $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getPromoteOrderId(): int
+    {
+        return $this->promoteOrderId;
+    }
+
+    /**
+     * @param int|null $promoteOrderId
+     *
+     * @return self
+     */
+    public function setPromoteOrderId(int $promoteOrderId = null): ConfirmRebateRequestBody
+    {
+        $this->promoteOrderId = $promoteOrderId;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Model/ConfirmRebateRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/ConfirmRebateRequestBody.php
@@ -22,9 +22,13 @@ class ConfirmRebateRequestBody
      */
     protected $code;
     /**
+     * @var int
+     */
+    protected $promoteOrderId;
+    /**
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
@@ -33,7 +37,7 @@ class ConfirmRebateRequestBody
      *
      * @return self
      */
-    public function setEmail($email = null)
+    public function setEmail($email = null): ConfirmRebateRequestBody
     {
         $this->email = $email;
 
@@ -42,7 +46,7 @@ class ConfirmRebateRequestBody
     /**
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }
@@ -51,9 +55,29 @@ class ConfirmRebateRequestBody
      *
      * @return self
      */
-    public function setCode($code = null)
+    public function setCode($code = null): ConfirmRebateRequestBody
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getPromoteOrderId(): int
+    {
+        return $this->promoteOrderId;
+    }
+
+    /**
+     * @param int|null $promoteOrderId
+     *
+     * @return self
+     */
+    public function setPromoteOrderId(int $promoteOrderId = null): ConfirmRebateRequestBody
+    {
+        $this->promoteOrderId = $promoteOrderId;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Model/UpdateDeliverableRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/UpdateDeliverableRequestBody.php
@@ -22,6 +22,10 @@ class UpdateDeliverableRequestBody
      */
     protected $deliverable;
     /**
+     * @var int
+     */
+    protected $promoteOrderId;
+    /**
      * @return string
      */
     public function getEmail()
@@ -54,6 +58,26 @@ class UpdateDeliverableRequestBody
     public function setDeliverable($deliverable = null)
     {
         $this->deliverable = $deliverable;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getPromoteOrderId(): int
+    {
+        return $this->promoteOrderId;
+    }
+
+    /**
+     * @param int|null $promoteOrderId
+     *
+     * @return self
+     */
+    public function setPromoteOrderId(int $promoteOrderId = null): ConfirmRebateRequestBody
+    {
+        $this->promoteOrderId = $promoteOrderId;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
@@ -39,6 +39,9 @@ class CancelRebateRequestBodyNormalizer extends SerializerAwareNormalizer implem
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});
         }
+        if (property_exists($data, 'promoteOrderId')) {
+            $object->setPromoteOrderId($data->{'promoteOrderId'});
+        }
 
         return $object;
     }
@@ -47,6 +50,9 @@ class CancelRebateRequestBodyNormalizer extends SerializerAwareNormalizer implem
         $data = new \stdClass();
         if (null !== $object->getEmail()) {
             $data->{'email'} = $object->getEmail();
+        }
+        if (null !== $object->getPromoteOrderId()) {
+            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
@@ -42,6 +42,9 @@ class ConfirmRebateRequestBodyNormalizer extends SerializerAwareNormalizer imple
         if (property_exists($data, 'code')) {
             $object->setCode($data->{'code'});
         }
+        if (property_exists($data, 'promoteOrderId')) {
+            $object->setPromoteOrderId($data->{'promoteOrderId'});
+        }
 
         return $object;
     }
@@ -53,6 +56,9 @@ class ConfirmRebateRequestBodyNormalizer extends SerializerAwareNormalizer imple
         }
         if (null !== $object->getCode()) {
             $data->{'code'} = $object->getCode();
+        }
+        if (null !== $object->getPromoteOrderId()) {
+            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
@@ -42,6 +42,9 @@ class UpdateDeliverableRequestBodyNormalizer extends SerializerAwareNormalizer i
         if (property_exists($data, 'deliverable')) {
             $object->setDeliverable($data->{'deliverable'});
         }
+        if (property_exists($data, 'promoteOrderId')) {
+            $object->setPromoteOrderId($data->{'promoteOrderId'});
+        }
 
         return $object;
     }
@@ -53,6 +56,9 @@ class UpdateDeliverableRequestBodyNormalizer extends SerializerAwareNormalizer i
         }
         if (null !== $object->getDeliverable()) {
             $data->{'deliverable'} = $object->getDeliverable();
+        }
+        if (null !== $object->getPromoteOrderId()) {
+            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
         }
 
         return $data;


### PR DESCRIPTION
Summary:
Email confirmation code passing to snagshout needs to be done based on the promote_order_id instead of email.
https://3.basecamp.com/4139135/buckets/12719549/todos/3416733962
Change https://github.com/snagshout/snagshout/pull/1086 to "Ready to review" after merged this branch